### PR TITLE
Deploy to live.mathics.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Build the JupyterLite site
         run: |
           make
+      - name: Deploy to live.mathics.org
+        run: echo live.mathics.org > dist/CNAME
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Just to make the URL a bit nicer than what it currently is, if you don't mind setting up the DNS records: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-a-subdomain